### PR TITLE
Simplify Vite proxy config for local and Docker

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:alpine
 
 WORKDIR /app
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,4 @@
-# Dockerfile.web
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /web
 

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,6 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import declarative_base, sessionmaker
 import os
 
 DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://postgres:postgres@db:5432/sat_annotator")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       - /web/node_modules
     working_dir: /web
     environment:
-      - VITE_API_URL=/api  # Now uses proxy
+      - VITE_API_PROXY_TARGET=http://backend:8000
+      - VITE_API_URL=/api
     depends_on:
       - backend
 

--- a/web/.env.docker
+++ b/web/.env.docker
@@ -1,0 +1,2 @@
+VITE_API_URL=/api
+VITE_API_PROXY_TARGET=http://backend:8000

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,8 @@
       "devDependencies": {
         "@eslint/js": "^9.21.0",
         "@tailwindcss/postcss": "^4.0.10",
+        "@types/http-proxy": "^1.17.16",
+        "@types/node": "^22.14.1",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.19",
         "@vitejs/plugin-react-swc": "^3.8.0",
@@ -22,9 +24,10 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",
+        "http-proxy": "^1.18.1",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5.3.3",
+        "typescript": "^5.8.3",
         "typescript-eslint": "^8.24.1",
         "vite": "^5.1.0"
       }
@@ -904,12 +907,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
@@ -2260,6 +2283,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2550,6 +2580,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2588,6 +2639,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ignore": {
@@ -3431,6 +3497,13 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -4173,9 +4246,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4208,6 +4281,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.14",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,8 @@
   "devDependencies": {
     "@eslint/js": "^9.21.0",
     "@tailwindcss/postcss": "^4.0.10",
+    "@types/http-proxy": "^1.17.16",
+    "@types/node": "^22.14.1",
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "@vitejs/plugin-react-swc": "^3.8.0",
@@ -24,9 +26,10 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
+    "http-proxy": "^1.18.1",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.3.3",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.24.1",
     "vite": "^5.1.0"
   }

--- a/web/src/components/ImageGallery.tsx
+++ b/web/src/components/ImageGallery.tsx
@@ -10,6 +10,9 @@ export const ImageGallery = ({ onSelectImage }: ImageGalleryProps) => {
   const [images, setImages] = useState<Image[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const API_BASE = import.meta.env.VITE_API_URL || '/api';
+
   const fetchImages = async () => {
     try {
       setLoading(true);
@@ -57,7 +60,7 @@ export const ImageGallery = ({ onSelectImage }: ImageGalleryProps) => {
           // Extract filename from file_path - handle both absolute and relative paths
           const filename = image.file_path.split('/').pop();
           // Use a relative path instead of API_BASE_URL
-          const imageUrl = `/api/uploads/${filename}`;
+          const imageUrl = `${API_BASE}/uploads/${filename}`;
           
           return (
             <div 

--- a/web/src/components/ImageViewer.tsx
+++ b/web/src/components/ImageViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
-import { api, SegmentationResponse, API_BASE_URL } from '../services/api';
+import { api, SegmentationResponse } from '../services/api';
 import type { Image } from '../services/api';
 
 interface ImageViewerProps {

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,17 +1,19 @@
-{
-  "compilerOptions": {
+{  "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2022",
     "lib": ["ES2023"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "composite": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "emitDeclarationOnly": true,
 
     /* Linting */
     "strict": true,


### PR DESCRIPTION
##  Simplify Vite Proxy Config for Local & Docker Environments

### Description

This PR simplifies the Vite dev server proxy configuration to work both **locally** and when running inside **Docker**. It removes unnecessary type declarations and custom `configure`/`errorHandler` logic to avoid type mismatches with Vite’s expectations.

###  Changes

- Simplified `vite.config.ts` proxy block
- Removed complex `http-proxy` configuration
- Ensured compatibility with `.env` usage and Docker-based setup

###  How to Test

#### 1. *Run Locally*

**Backend:**
```bash
cd app
uvicorn app.main:app --reload
```

**Frontend:**
```bash
cd web
npm install
npm run dev
```
**Ensure your .env.local file exists in the web/ folder:**
```
VITE_API_URL=/api
VITE_API_PROXY_TARGET=http://localhost:8000
```
#### 2. *With Docker*

**Build and Start All Services**
```bash
docker-compose up --build
```
This starts:

- **backend** at [http://localhost:8000](http://localhost:8000)
- **frontend** at [http://localhost:5173](http://localhost:5173)

**Ensure your .env.docker file exists in the web/ folder:**
```
VITE_API_URL=/api
VITE_API_PROXY_TARGET=http://backend:8000
```