### PR TITLE
Fix docker-compose command not found error in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     
     - name: Build and tag Docker images
       run: |
-        docker-compose build
+        docker compose build
       
     # Uncomment and configure the following if you want to push to Docker Hub or another registry
     # - name: Login to Docker Hub
@@ -83,4 +83,4 @@ jobs:
     # 
     # - name: Push Docker images
     #   run: |
-    #     docker-compose push
+    #     docker compose push


### PR DESCRIPTION
Updated CI workflow to use `docker compose` command (with space) instead of `docker-compose` (with hyphen) to resolve the "command not found" error in GitHub Actions runners. This change ensures the Docker build stage completes successfully.