### PR TITLE
Fix Docker build failure by replacing unsupported Alpine packages

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -1,11 +1,11 @@
-FROM python:3.11-alpine
+FROM python:3.11-alpine3.19
 
 WORKDIR /app
 
 # Install system dependencies for OpenCV and PyTorch
 RUN apk update && apk add --no-cache \
-    libgl \
-    mesa-gl \
+    mesa-gles \
+    mesa \
     glib \
     git \
     wget \


### PR DESCRIPTION
This PR resolves the Docker build failure in the CI/CD pipeline by replacing the non-existent `libgl` and `mesa-gl` packages with their Alpine Linux equivalents (`mesa-gles` and `mesa`). Also updated the Python base image to `3.11-alpine3.19` to address security vulnerabilities.