### PR TITLE
refactor: Replace GeoJSON terminology with JSON throughout project

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project is sponsored by the Egyptian Space Agency (EgSA).
 - AI-powered segmentation using Segment Anything Model (SAM)
 - Point-prompt based segmentation
 - Automatic polygon generation from segmentation masks
-- GeoJSON export format support
+- JSON export format support
 
 **Planned:**
 - Multiple prompt types (box, points, text)
@@ -226,7 +226,7 @@ The application uses PostgreSQL with the following structure:
 Relationships:
 - An image can have multiple annotation files
 - Annotation files can be linked to AI models that generated them
-- Annotations store GeoJSON formatted polygons
+- Annotations store JSON formatted polygons
 
 ## Development Roadmap
 
@@ -237,7 +237,7 @@ Relationships:
 - [x] Image metadata extraction
 - [x] SAM model integration
 - [x] Point-prompt segmentation
-- [x] GeoJSON export
+- [x] JSON export
 - [ ] Multiple prompt types support
 - [ ] Manual annotation interface
 - [ ] Additional export formats

--- a/web/js/annotations.js
+++ b/web/js/annotations.js
@@ -177,10 +177,9 @@ class AnnotationManager {
                         // Extract label from properties
                         if (feature.properties) {
                             label = feature.properties.label || feature.properties.class_name || 'Unlabeled';
-                            type = feature.properties.type || 'polygon';
-                        }
+                            type = feature.properties.type || 'polygon';                        }
                         
-                        // Extract polygon coordinates from GeoJSON
+                        // Extract polygon coordinates from JSON
                         if (feature.geometry && feature.geometry.type === 'Polygon') {
                             const coordinates = feature.geometry.coordinates[0]; // First ring of polygon
                             polygon = coordinates.map(coord => [coord[0], coord[1]]);


### PR DESCRIPTION
This pull request replaces the use of GeoJSON with JSON for annotation storage and processing across the application. The changes include updates to documentation, backend logic, and frontend handling to reflect this migration.

### Documentation Updates:
* Updated `README.md` to replace references to "GeoJSON" with "JSON" in export format descriptions, annotation storage, and completed roadmap items. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R30) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L229-R229) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L240-R240)

### Backend Updates:
* Replaced all occurrences of "GeoJSON" with "JSON" in `app/routers/session_segmentation.py`, including variable names, comments, and data handling logic for saving, retrieving, and updating annotations. [[1]](diffhunk://#diff-6289d8fed491eecf0caa4531012d0f6a86b8a1a688972538135881a5308916e2L119-R122) [[2]](diffhunk://#diff-6289d8fed491eecf0caa4531012d0f6a86b8a1a688972538135881a5308916e2L191-R195) [[3]](diffhunk://#diff-6289d8fed491eecf0caa4531012d0f6a86b8a1a688972538135881a5308916e2L257-R256) [[4]](diffhunk://#diff-6289d8fed491eecf0caa4531012d0f6a86b8a1a688972538135881a5308916e2L318-R324)
* Adjusted the annotation creation and update processes to ensure JSON-formatted data is correctly handled and saved. [[1]](diffhunk://#diff-6289d8fed491eecf0caa4531012d0f6a86b8a1a688972538135881a5308916e2L276-R277) [[2]](diffhunk://#diff-6289d8fed491eecf0caa4531012d0f6a86b8a1a688972538135881a5308916e2L338-R336)

### Frontend Updates:
* Modified `web/js/annotations.js` to update comments and logic for extracting polygon coordinates from JSON instead of GeoJSON.